### PR TITLE
Fix compilation under Catalyst

### DIFF
--- a/Sources/Motion/Utilities/AnimationDriver.swift
+++ b/Sources/Motion/Utilities/AnimationDriver.swift
@@ -67,7 +67,7 @@ final class CoreAnimationDriver: AnimationDriver {
 
 #endif
 
-#if canImport(Cocoa)
+#if os(macOS)
 import Cocoa
 
 typealias SystemAnimationDriver = CoreVideoDriver


### PR DESCRIPTION
When compiling for Catalyst, it seems like `#if canImport(Cocoa)` is considered true, and `import Cocoa` succeeds — but Cocoa classes still aren't available. So you get errors like this:

<img width="822" alt="Screen Shot 2022-02-07 at 11 34 16 PM" src="https://user-images.githubusercontent.com/3059249/152918924-c256789f-55e1-463a-8dd6-6c187eff329e.png">

`#if os(macOS)` appears to behave as expected (false under Catalyst) and is already used in this project.

thx for the library, btw! great stuff