### PR TITLE
Support Pro Motion Displays by Default on iOS

### DIFF
--- a/Example/MotionExample-iOS/MotionExample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/MotionExample-iOS/MotionExample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,12 +20,21 @@
         }
       },
       {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "swift-numerics",
         "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
-          "revision": "6583ac70c326c3ee080c1d42d9ca3361dca816cd",
-          "version": "0.1.0"
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Example/MotionExample-iOS/MotionExample-iOS/Info.plist
+++ b/Example/MotionExample-iOS/MotionExample-iOS/Info.plist
@@ -62,5 +62,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/Tests/MotionTests/MotionTests.swift
+++ b/Tests/MotionTests/MotionTests.swift
@@ -173,6 +173,25 @@ final class MotionTests: XCTestCase {
         _ = spring
     }
 
+    #if os(iOS)
+    func testChangingAnimatorPreferredFrameRateRange() {
+        let defaultFPS = 60
+
+        if #available(iOS 15.0, *) {
+            Animator.shared.preferredFrameRateRange = .default
+        }
+
+        XCTAssert(Animator.shared.preferredFramesPerSecond == defaultFPS)
+
+        let proMotionFPS = 120
+        if #available(iOS 15.0, *) {
+            Animator.shared.preferredFrameRateRange = CAFrameRateRange(minimum: 80.0, maximum: Float(proMotionFPS), preferred: Float(proMotionFPS))
+        }
+
+        XCTAssert(Animator.shared.preferredFramesPerSecond == proMotionFPS)
+    }
+    #endif
+
     // MARK: - RubberBanding Tests
 
     func testRubberBandingScalar() {


### PR DESCRIPTION
This adds support for enabling higher refresh rates by default on iOS apps assuming the following is added to the apps Info.plist `<key>CADisableMinimumFrameDurationOnPhone</key><true/>`. 

More info / docs [here](https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro)

It can be disabled / changed via `Animator.shared.preferredFrameRateRange`.