### PR TITLE
Support toValue on DecayAnimation; Add roundingFactor

### DIFF
--- a/Benchmark/.swiftpm/xcode/xcshareddata/xcschemes/MotionBenchmarkRunner.xcscheme
+++ b/Benchmark/.swiftpm/xcode/xcshareddata/xcschemes/MotionBenchmarkRunner.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Sources/Motion/Animations/BasicAnimation.swift
+++ b/Sources/Motion/Animations/BasicAnimation.swift
@@ -82,7 +82,7 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
     }
 
     #if DEBUG
-    internal func solveAccumulatedTime<SIMDType: SupportedSIMD>(easingFunction: inout EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, value: inout SIMDType) -> CFTimeInterval? {
+    internal func solveAccumulatedTime<SIMDType: SupportedSIMD>(easingFunction: EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, value: inout SIMDType) -> CFTimeInterval? {
         /* Must Be Mirrored Below */
         
         if !range.contains(value) {
@@ -106,7 +106,7 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
     @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
-    internal func solveAccumulatedTime<SIMDType: SupportedSIMD>(easingFunction: inout EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, value: inout SIMDType) -> CFTimeInterval? {
+    internal func solveAccumulatedTime<SIMDType: SupportedSIMD>(easingFunction: EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, value: inout SIMDType) -> CFTimeInterval? {
         /* Must Be Mirrored Above */
 
         if !range.contains(value) {
@@ -127,7 +127,7 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
     internal func attemptToUpdateAccumulatedTimeToMatchValue() {
         if !_value.approximatelyEqual(to: _fromValue, epsilon: resolvingEpsilon) && !_value.approximatelyEqual(to: _toValue, epsilon: resolvingEpsilon) {
             // Try to find out where we are in the animation.
-            if let accumulatedTime = solveAccumulatedTime(easingFunction: &easingFunction, range: &_range, value: &_value) {
+            if let accumulatedTime = solveAccumulatedTime(easingFunction: easingFunction, range: &_range, value: &_value) {
                 self.accumulatedTime = accumulatedTime * duration
             } else {
                 // Unexpected state, reset to beginning of animation.
@@ -217,7 +217,7 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
 
         let fraction = min(max(0.0, accumulatedTime / duration), 1.0)
 
-        tickOptimized(easingFunction: &easingFunction, range: &_range, fraction: Value.SIMDType.Scalar(fraction), value: &_value)
+        tickOptimized(easingFunction: easingFunction, range: &_range, fraction: Value.SIMDType.Scalar(fraction), value: &_value)
 
         _valueChanged?(value)
 
@@ -230,10 +230,10 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
 
     // See docs in SpringAnimation.swift for why this `@_specialize` stuff exists.
     #if DEBUG
-    internal func tickOptimized<SIMDType: SupportedSIMD>(easingFunction: inout EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, fraction: SIMDType.Scalar, value: inout SIMDType) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
+    internal func tickOptimized<SIMDType: SupportedSIMD>(easingFunction: EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, fraction: SIMDType.Scalar, value: inout SIMDType) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
         /* Must Be Mirrored Below */
 
-        value = easingFunction.solveInterpolatedValue(range, fraction: fraction)
+        value = easingFunction.solveInterpolatedValueSIMD(range, fraction: fraction)
     }
     #else
     @_specialize(kind: partial, where SIMDType == SIMD2<Float>)
@@ -250,10 +250,10 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
     @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
-    internal func tickOptimized<SIMDType: SupportedSIMD>(easingFunction: inout EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, fraction: SIMDType.Scalar, value: inout SIMDType) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
+    internal func tickOptimized<SIMDType: SupportedSIMD>(easingFunction: EasingFunction<SIMDType>, range: inout ClosedRange<SIMDType>, fraction: SIMDType.Scalar, value: inout SIMDType) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
         /* Must Be Mirrored Above */
 
-        value = easingFunction.solveInterpolatedValue(range, fraction: fraction)
+        value = easingFunction.solveInterpolatedValueSIMD(range, fraction: fraction)
     }
     #endif
     

--- a/Sources/Motion/Animations/Functions/DecayFunction.swift
+++ b/Sources/Motion/Animations/Functions/DecayFunction.swift
@@ -66,7 +66,7 @@ public struct DecayFunction<Value: SIMDRepresentable> {
      - Returns: The new value as its velocity decays.
      */
     @inlinable public func solveSIMD(dt: Value.SIMDType.Scalar, x0: Value.SIMDType, velocity: inout Value.SIMDType) -> Value.SIMDType {
-        let d_1000_dt = Value.SIMDType.Scalar.pow(decayConstant, 1000.0 * dt)
+        let d_1000_dt = Value.SIMDType.Scalar.pow(decayConstant, dt * 1000.0)
 
         // Analytic decay equation with constants extracted out.
         let x = x0 + velocity * ((d_1000_dt - 1.0) * one_ln_decayConstant_1000)
@@ -116,7 +116,7 @@ public struct DecayFunction<Value: SIMDRepresentable> {
     @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
     @inlinable public func solveToValueSIMD<SIMDType: SupportedSIMD>(value: SIMDType, velocity: SIMDType, decayConstant: SIMDType.Scalar, roundingFactor: SIMDType.Scalar) -> SIMDType {
-        let decay = (1000.0 * SIMDType.Scalar.log(decayConstant))
+        let decay = (SIMDType.Scalar.log(decayConstant) * 1000.0)
         let toValue = value - velocity / decay
         return roundSIMD(toValue, toNearest: roundingFactor)
     }
@@ -164,7 +164,7 @@ public struct DecayFunction<Value: SIMDRepresentable> {
     @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
     @inlinable public func solveVelocitySIMD<SIMDType: SupportedSIMD>(value: SIMDType, toValue: SIMDType, decayConstant: SIMDType.Scalar) -> SIMDType {
-        let decay = (1000.0 * SIMDType.Scalar.log(decayConstant))
+        let decay = (SIMDType.Scalar.log(decayConstant) * 1000.0)
         return (value - toValue) * decay
     }
 

--- a/Sources/Motion/Animations/Functions/DecayFunction.swift
+++ b/Sources/Motion/Animations/Functions/DecayFunction.swift
@@ -29,6 +29,13 @@ public struct DecayFunction<Value: SIMDRepresentable> {
         }
     }
 
+    /**
+     A value used to round the final value. Defaults to 0.5.
+
+     - Description: This is useful when implementing things like scroll views, where the final value will rest on nice pixel values so that text remains sharp. It defaults to 0.5, but applying 1.0 / the scale factor of the view will lead to similar behaviours as `UIScrollView`. Setting this to `0.0` disables any rounding.
+     */
+    public var roundingFactor: Value.SIMDType.Scalar = 0.5
+
     /// A cached invocation of `1.0 / (ln(decayConstant) * 1000.0)`
     private(set) public var one_ln_decayConstant_1000: Value.SIMDType.Scalar = 0.0
 
@@ -54,7 +61,7 @@ public struct DecayFunction<Value: SIMDRepresentable> {
      - Parameters:
         - dt: The duration in seconds since the last frame.
         - x0: The starting value.
-        - velocity: The velocity of the spring.
+        - velocity: The velocity of the decay.
 
      - Returns: The new value as its velocity decays.
      */
@@ -83,6 +90,152 @@ public struct DecayFunction<Value: SIMDRepresentable> {
         return Value(x)
     }
 
+    /**
+     Solves the destination for the decay function based on the given parameters for a `SupportedSIMD` type.
+
+     - Parameters:
+        - value: The starting value.
+        - velocity: The starting velocity of the decay.
+        - decayConstant: The decay constant.
+        - roundingFactor: The desired rounding factor. Supplying `0.0` will disable any rounding.
+
+     - Returns: The destination when the decay reaches zero velocity.
+     */
+    @_specialize(kind: partial, where SIMDType == SIMD2<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD2<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
+    @inlinable public func solveToValueSIMD<SIMDType: SupportedSIMD>(value: SIMDType, velocity: SIMDType, decayConstant: SIMDType.Scalar, roundingFactor: SIMDType.Scalar) -> SIMDType {
+        let decay = (1000.0 * SIMDType.Scalar.log(decayConstant))
+        let toValue = value - velocity / decay
+        return roundSIMD(toValue, toNearest: roundingFactor)
+    }
+
+    /**
+     Solves the destination for the decay function based on the given parameters for a `Value`.
+
+     - Parameters:
+        - value: The starting value.
+        - velocity: The starting velocity of the decay.
+        - decayConstant: The decay constant.
+        - roundingFactor: The desired rounding factor. Supplying `0.0` will disable any rounding.
+
+     - Returns: The destination when the decay reaches zero velocity.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but for `Value` types.
+     */
+    @inlinable public func solveToValue(value: Value, velocity: Value) -> Value {
+        let toValue = solveToValueSIMD(value: value.simdRepresentation(), velocity: velocity.simdRepresentation(), decayConstant: decayConstant, roundingFactor: roundingFactor)
+        return Value(toValue)
+    }
+
+    /**
+     Solves the velocity required to reach a desired destination for a decay function based on the given parameters for a `SupportedSIMD` type.
+
+     - Parameters:
+        - value: The starting value.
+        - toValue: The desired destination for the decay.
+        - decayConstant: The decay constant.
+
+     - Returns: The velocity required to reach `toValue`.
+     */
+    @_specialize(kind: partial, where SIMDType == SIMD2<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD2<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
+    @inlinable public func solveVelocitySIMD<SIMDType: SupportedSIMD>(value: SIMDType, toValue: SIMDType, decayConstant: SIMDType.Scalar) -> SIMDType {
+        let decay = (1000.0 * SIMDType.Scalar.log(decayConstant))
+        return (value - toValue) * decay
+    }
+
+    /**
+     Solves the velocity required to reach a desired destination for a decay function based on the given parameters for a `Value`.
+
+     - Parameters:
+        - value: The starting value.
+        - toValue: The desired destination for the decay.
+
+     - Returns: The velocity required to reach `toValue`.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but for `Value` types.
+     */
+    @inlinable public func solveVelocity(value: Value, toValue: Value) -> Value {
+        let velocity = solveVelocitySIMD(value: value.simdRepresentation(), toValue: toValue.simdRepresentation(), decayConstant: decayConstant)
+        return Value(velocity)
+    }
+
+    // MARK: - Rounding
+
+    /**
+     Rounds the given value to the nearest decimal point and factor (supplied by the `roundingFactor`).
+     - Description: i.e. supplying a rounding factor of `0.5` for a value of `3.70`, will return `3.5`.
+
+     - Parameters:
+        - value: The value to round.
+        - toValue: The rounding factor.
+
+     - Returns: The value rounded to the nearest supplied decimal and factor.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but for `Value` types.
+     */
+    @inlinable public func round(_ value: Value, toNearest roundingFactor: Value.SIMDType.Scalar) -> Value {
+        let roundedValue = roundSIMD(value.simdRepresentation(), toNearest: roundingFactor)
+        return Value(roundedValue)
+    }
+
+    /**
+     Rounds the given value to the nearest decimal point and factor (supplied by the `roundingFactor`).
+     - Description: i.e. supplying a rounding factor of `0.5` for a value of `3.70`, will return `3.5`.
+
+     - Parameters:
+        - value: The value to round.
+        - toValue: The rounding factor.
+
+     - Returns: The value rounded to the nearest supplied decimal and factor.
+     */
+    @_specialize(kind: partial, where SIMDType == SIMD2<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD2<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD3<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD4<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD8<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD16<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
+    @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
+    @inlinable public func roundSIMD<SIMDType: SupportedSIMD>(_ value: SIMDType, toNearest roundingFactor: SIMDType.Scalar) -> SIMDType {
+        if roundingFactor.approximatelyEqual(to: 0.0) {
+            return value
+        }
+
+        let rounded = (value / roundingFactor).rounded(.up) * roundingFactor
+        return rounded
+    }
+
 }
 
 extension DecayFunction where Value: SupportedSIMD {
@@ -94,6 +247,34 @@ extension DecayFunction where Value: SupportedSIMD {
      */
     @inlinable public func solve(dt: Value.SIMDType.Scalar, x0: Value.SIMDType, velocity: inout Value.SIMDType) -> Value.SIMDType {
         return solveSIMD(dt: dt, x0: x0, velocity: &velocity)
+    }
+
+    /**
+     Solves the decay function for a given `Value`.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but acts as a fast path to call the `solveToValueSIMD` method directly instead of boxing and unboxing the same value.
+     */
+    @inlinable public func solveToValue(value: Value.SIMDType, velocity: Value.SIMDType) -> Value.SIMDType {
+        return solveToValueSIMD(value: value, velocity: velocity, decayConstant: decayConstant, roundingFactor: roundingFactor)
+    }
+
+    /**
+     Solves the velocity required to reach a desired destination for a decay function based on the given parameters for a `Value`.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but acts as a fast path to call the `solveVelocitySIMD` method directly instead of boxing and unboxing the same value.
+     */
+    @inlinable public func solveVelocity(value: Value.SIMDType, toValue: Value.SIMDType) -> Value.SIMDType {
+        return solveVelocitySIMD(value: value, toValue: toValue, decayConstant: decayConstant)
+    }
+
+    /**
+     Rounds the given value to the nearest decimal point and factor (supplied by the `roundingFactor`).
+     - Description: i.e. supplying a rounding factor of `0.5` for a value of `3.70`, will return `3.5`.
+
+     - Note: This mirrors the `SupportedSIMD` version above, but acts as a fast path to call the `roundSIMD` method directly instead of boxing and unboxing the same value.
+     */
+    @inlinable public func round(_ value: Value.SIMDType, toNearest roundingFactor: Value.SIMDType.Scalar) -> Value.SIMDType {
+        return roundSIMD(value, toNearest: roundingFactor)
     }
 
 }

--- a/Sources/Motion/Animations/Functions/EasingFunctions.swift
+++ b/Sources/Motion/Animations/Functions/EasingFunctions.swift
@@ -54,7 +54,7 @@ public struct EasingFunction<Value: SIMDRepresentable>: Hashable {
 
      - Returns: An interpolated SIMD value between the supplied range's bounds based on a fraction (from 0.0 to 1.0) of the easing function.
      */
-    @inlinable public func solveInterpolatedValueSIMD(_ range: ClosedRange<Value.SIMDType>, fraction: Value.SIMDType.Scalar) -> Value.SIMDType {
+    @inlinable public func solveInterpolatedValueSIMD<SIMDType: SupportedSIMD>(_ range: ClosedRange<SIMDType>, fraction: SIMDType.Scalar) -> SIMDType where SIMDType.Scalar == Value.SIMDType.Scalar {
         let x = bezier.solve(x: fraction)
 
         let min = range.lowerBound

--- a/Sources/Motion/Animations/Functions/SpringFunction.swift
+++ b/Sources/Motion/Animations/Functions/SpringFunction.swift
@@ -15,6 +15,7 @@ import simd
  - Note: This can be used on its own, but it's mainly used by `SpringAnimation`'s `tick` method.
  - SeeAlso: `SpringAnimation`
 */
+
 public struct SpringFunction<Value: SIMDRepresentable> {
 
     /**
@@ -165,12 +166,13 @@ public struct SpringFunction<Value: SIMDRepresentable> {
         typealias SIMDType = Value.SIMDType
         let x: SIMDType
         if dampingRatio < 1.0 {
-            let decayEnvelope = SIMDType.Scalar.exp(-dampingRatio * w0 * dt)
+            let dampingRatio_w0 = dampingRatio * w0
+            let decayEnvelope = SIMDType.Scalar.exp(-dampingRatio_w0 * dt)
 
             let sin_wD_dt = SIMDType.Scalar.sin(wD * dt)
             let cos_wD_dt = SIMDType.Scalar.cos(wD * dt)
 
-            let velocity_x0_dampingRatio_w0 = (velocity + x0 * (dampingRatio * w0))
+            let velocity_x0_dampingRatio_w0 = (velocity + x0 * dampingRatio_w0)
 
             let A = x0
             let B = velocity_x0_dampingRatio_w0 / wD
@@ -180,7 +182,7 @@ public struct SpringFunction<Value: SIMDRepresentable> {
 
             // Derivative of the above analytic equation to get the speed of a spring. (velocity)
             let d_x = velocity_x0_dampingRatio_w0 * cos_wD_dt - x0 * (wD * sin_wD_dt)
-            velocity = -(dampingRatio * w0 * x - decayEnvelope * d_x)
+            velocity = -(dampingRatio_w0 * x - decayEnvelope * d_x)
         } else if dampingRatio.approximatelyEqual(to: 1.0) {
             let decayEnvelope = SIMDType.Scalar.exp(-w0 * dt)
 

--- a/Sources/Motion/Animations/SpringAnimation.swift
+++ b/Sources/Motion/Animations/SpringAnimation.swift
@@ -326,7 +326,7 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
             previousValueDelta = nil
         }
 
-        tickOptimized(Value.SIMDType.Scalar(frame.duration), spring: &spring, value: &_value, toValue: &_toValue, velocity: &_velocity, clampingRange: &_clampingRange)
+        tickOptimized(Value.SIMDType.Scalar(frame.duration), spring: spring, value: &_value, toValue: &_toValue, velocity: &_velocity, clampingRange: &_clampingRange)
 
         let resolvedState = hasResolved(value: &_value, epsilon: &resolvingEpsilon, toValue: &_toValue, velocity: &_velocity, previousValueDelta: &previousValueDelta)
         if !resolvedState.valueResolved || !resolvedState.velocityResolved {
@@ -351,12 +351,12 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
      Note that this optimization only happens on Release builds as building constantly for Debug is fairly slow.
      */
     #if DEBUG
-    internal func tickOptimized<SIMDType: SupportedSIMD>(_ dt: SIMDType.Scalar, spring: inout SpringFunction<SIMDType>, value: inout SIMDType, toValue: inout SIMDType, velocity: inout SIMDType, clampingRange: inout ClosedRange<SIMDType>?) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
+    internal func tickOptimized<SIMDType: SupportedSIMD>(_ dt: SIMDType.Scalar, spring: SpringFunction<SIMDType>, value: inout SIMDType, toValue: inout SIMDType, velocity: inout SIMDType, clampingRange: inout ClosedRange<SIMDType>?) where SIMDType.Scalar == SIMDType.SIMDType.Scalar, SIMDType == SIMDType.SIMDType {
         /* Must Be Mirrored Below */
 
         let x0 = toValue - value
 
-        let x = spring.solve(dt: dt, x0: x0, velocity: &velocity)
+        let x = spring.solveSIMD(dt: dt, x0: x0, velocity: &velocity)
 
         value = toValue - x
 
@@ -379,12 +379,12 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
     @_specialize(kind: partial, where SIMDType == SIMD32<Double>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Float>)
     @_specialize(kind: partial, where SIMDType == SIMD64<Double>)
-    internal func tickOptimized<SIMDType: SupportedSIMD>(_ dt: SIMDType.Scalar, spring: inout SpringFunction<SIMDType>, value: inout SIMDType, toValue: inout SIMDType, velocity: inout SIMDType, clampingRange: inout ClosedRange<SIMDType>?) where SIMDType.Scalar == SIMDType.SIMDType.Scalar {
+    internal func tickOptimized<SIMDType: SupportedSIMD>(_ dt: SIMDType.Scalar, spring: SpringFunction<SIMDType>, value: inout SIMDType, toValue: inout SIMDType, velocity: inout SIMDType, clampingRange: inout ClosedRange<SIMDType>?) where SIMDType.Scalar == SIMDType.SIMDType.Scalar, SIMDType == SIMDType.SIMDType {
         /* Must Be Mirrored Above */
 
         let x0 = toValue - value
 
-        let x = spring.solve(dt: dt, x0: x0, velocity: &velocity)
+        let x = spring.solveSIMD(dt: dt, x0: x0, velocity: &velocity)
 
         value = toValue - x
 

--- a/Sources/Motion/Protocols/EquatableEnough.swift
+++ b/Sources/Motion/Protocols/EquatableEnough.swift
@@ -113,116 +113,20 @@ public extension EquatableEnough where Self: FloatingPoint & FloatingPointInitia
     return copy
 }
 
-/*
- Note: These are probably not the most optimal, especially in the bigger SIMD types. I haven't yet figured out how to do an equality within a given tolerance across all values simultaneously, so for now it's just a `reduce`.
- In addition, having to write all of these generics is probably wrong, I just haven't gotten around to simplifying it all yet and doing performance tracing on the change / verifying specialization.
-
- Something like extension `EquatableEnough where Self: SupportedSIMD` would probably be better.
+/**
+ - Note: These are probably not the most optimal, especially in the bigger SIMD types. I haven't yet figured out how to do an equality within a given tolerance across all values simultaneously, so for now it's just an early return if anything isn't approximately equal.
 */
-extension SIMD2: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
+extension SupportedSIMD where Self: EquatableEnough & Comparable, Scalar: SupportedScalar {
 
-    /// Declares whether or not another `SIMD2` is equal to `self` within a given tolerance (epsilon).
     @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
+        for i in 0..<indices.count {
+            let equal = self[i].approximatelyEqual(to: other[i], epsilon: epsilon)
+            if !equal {
+                return false
+            }
         }
-    }
 
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-
-extension SIMD3: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD3` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
-    }
-
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-extension SIMD4: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD4` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
-    }
-
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-extension SIMD8: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD8` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
-    }
-
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-extension SIMD16: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD16` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
-    }
-
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-extension SIMD32: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD32` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
-    }
-
-    /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).
-    @inlinable public static func < (lhs: Self, rhs: Self) -> Bool {
-        return all(lhs .< rhs)
-    }
-
-}
-
-extension SIMD64: EquatableEnough, Comparable where Scalar: FloatingPointInitializable & EquatableEnough {
-
-    /// Declares whether or not another `SIMD64` is equal to `self` within a given tolerance (epsilon).
-    @inlinable public func approximatelyEqual(to other: Self, epsilon: Scalar = .epsilon) -> Bool {
-        return self.indices.reduce(true) {
-            return $0 && self[$1].approximatelyEqual(to: other[$1], epsilon: epsilon)
-        }
+        return true
     }
 
     /// Returns whether or not all values of `lhs` (individually, sequentially) are less than all values of `rhs` (following the same ordering as `lhs`).

--- a/Sources/Motion/Protocols/SIMDRepresentable.swift
+++ b/Sources/Motion/Protocols/SIMDRepresentable.swift
@@ -29,13 +29,13 @@ public protocol SupportedScalar: SIMDScalar, FloatingPointInitializable, Equatab
 extension Float: SupportedScalar {}
 extension Double: SupportedScalar {}
 
-extension SIMD2: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD3: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD4: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD8: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD16: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD32: SupportedSIMD where Scalar: SupportedScalar {}
-extension SIMD64: SupportedSIMD where Scalar: SupportedScalar {}
+extension SIMD2: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD3: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD4: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD8: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD16: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD32: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
+extension SIMD64: SupportedSIMD, Comparable, EquatableEnough where Scalar: SupportedScalar {}
 
 // MARK: - SIMDRepresentable
 

--- a/Sources/Motion/Protocols/SIMDRepresentable.swift
+++ b/Sources/Motion/Protocols/SIMDRepresentable.swift
@@ -23,6 +23,7 @@ public protocol SupportedScalar: SIMDScalar, FloatingPointInitializable, Equatab
     static func sin(_ x: Self) -> Self
     static func cos(_ x: Self) -> Self
     static func pow(_ x: Self, _ n: Int) -> Self
+    static func log(_ x: Self) -> Self
 
 }
 

--- a/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
+++ b/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
@@ -92,7 +92,7 @@ extension SpringAnimation: CAKeyframeAnimationEmittable where Value: CAKeyframeA
         var t = 0.0
         var hasResolved = false
         while !hasResolved {
-            tickOptimized(Value.SIMDType.Scalar(dt), spring: &spring, value: &value, toValue: &_toValue, velocity: &velocity, clampingRange: &_clampingRange)
+            tickOptimized(Value.SIMDType.Scalar(dt), spring: spring, value: &value, toValue: &_toValue, velocity: &velocity, clampingRange: &_clampingRange)
             let resolvedState = self.hasResolved(value: &value, epsilon: &resolvingEpsilon, toValue: &_toValue, velocity: &velocity, previousValueDelta: &previousValueDelta)
 
             if resolvesUponReachingToValue {
@@ -110,6 +110,7 @@ extension SpringAnimation: CAKeyframeAnimationEmittable where Value: CAKeyframeA
 
         values.append(toValue.toKeyframeValue())
         keyTimes.append(t as NSNumber)
+        t += dt
 
         return t
     }
@@ -159,7 +160,7 @@ extension BasicAnimation: CAKeyframeAnimationEmittable where Value: CAKeyframeAn
         var t = 0.0
         var hasResolved = false
         while !hasResolved {
-            tickOptimized(easingFunction: &easingFunction, range: &_range, fraction: Value.SIMDType.Scalar(t / duration), value: &value)
+            tickOptimized(easingFunction: easingFunction, range: &_range, fraction: Value.SIMDType.Scalar(t / duration), value: &value)
             hasResolved = self.hasResolved(value: &value, epsilon: &resolvingEpsilon, toValue: &_toValue)
 
             let nsValue = Value(value).toKeyframeValue()

--- a/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
+++ b/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
@@ -128,7 +128,7 @@ extension DecayAnimation: CAKeyframeAnimationEmittable where Value: CAKeyframeAn
         var t = 0.0
         var hasResolved = false
         while !hasResolved {
-            tickOptimized(Value.SIMDType.Scalar(dt), decay: &decay, value: &value, velocity: &velocity)
+            tickOptimized(Value.SIMDType.Scalar(dt), decay: decay, value: &value, velocity: &velocity)
             hasResolved = self.hasResolved(velocity: &velocity)
 
             let nsValue = Value(value).toKeyframeValue()
@@ -138,7 +138,9 @@ extension DecayAnimation: CAKeyframeAnimationEmittable where Value: CAKeyframeAn
             t += dt
         }
 
-        t -= dt
+        values.append(toValue.toKeyframeValue())
+        keyTimes.append(t as NSNumber)
+        t += dt
 
         return t
     }

--- a/Tests/MotionTests/BasicAnimationTests.swift
+++ b/Tests/MotionTests/BasicAnimationTests.swift
@@ -116,7 +116,7 @@ final class BasicAnimationTests: XCTestCase {
         basicAnimation.toValue = 10.0
         basicAnimation.duration = 1.0
 
-        let keyframeAnimation = basicAnimation.keyframeAnimation()
+        let keyframeAnimation = basicAnimation.keyframeAnimation(forFramerate: 60)
 
         XCTAssertEqual(keyframeAnimation.calculationMode, .discrete)
         XCTAssertFalse(keyframeAnimation.values?.isEmpty ?? true)

--- a/Tests/MotionTests/DecayAnimationTests.swift
+++ b/Tests/MotionTests/DecayAnimationTests.swift
@@ -78,18 +78,62 @@ final class DecayAnimationTests: XCTestCase {
         wait(for: [expectCompletionCalled, expectDecayVelocityZero], timeout: 0.0)
     }
 
+    func testDecayToValueCalculation() {
+        let decay = DecayAnimation<CGFloat>()
+        decay.velocity = 2000.0
+
+        XCTAssertTrue(decay.toValue.approximatelyEqual(to: 998.999))
+        XCTAssertTrue(decay._toValue.approximatelyEqual(to: SIMD2<Double>(998.999, 0.0)))
+
+        let decay2 = DecayAnimation<CGPoint>()
+        decay2.velocity = CGPoint(x: 1000.0, y: 2000.0)
+
+        XCTAssertTrue(decay2.toValue.x.approximatelyEqual(to: 499.499) && decay2.toValue.y.approximatelyEqual(to: 998.999))
+        XCTAssertTrue(decay2._toValue.approximatelyEqual(to: SIMD2<Double>(499.499, 998.999)))
+    }
+
+    func testDecayVelocityCalculation() {
+        let decay = DecayAnimation<CGFloat>()
+        decay.toValue = 998.999
+
+        XCTAssertTrue(decay.velocity.approximatelyEqual(to: 2000.0, epsilon: 0.01))
+        XCTAssertTrue(decay._velocity.approximatelyEqual(to: SIMD2<Double>(2000.0, 0.0), epsilon: 0.01))
+
+        let decay2 = DecayAnimation<CGPoint>()
+        decay2.toValue = CGPoint(x: 499.499, y: 998.999)
+
+        XCTAssertTrue(decay2.velocity.x.approximatelyEqual(to: 1000.0, epsilon: 0.01) && decay2.velocity.y.approximatelyEqual(to: 2000.0, epsilon: 0.01))
+        XCTAssertTrue(decay2._velocity.approximatelyEqual(to: SIMD2<Double>(1000.0, 2000.0), epsilon: 0.01))
+    }
+
+    func testDecayRoundingFactorApplication() {
+        let decay = DecayAnimation<CGFloat>()
+        decay.roundingFactor = 1.0
+        decay.velocity = 200.0
+
+        XCTAssertTrue(decay.velocity.approximatelyEqual(to: 200.2, epsilon: 0.01))
+        XCTAssertTrue(decay.toValue.approximatelyEqual(to: 100.0, epsilon: 0.0001))
+
+        let decay2 = DecayAnimation<CGFloat>()
+        decay2.roundingFactor = 1.0 / 3.0 // i.e. 3x device
+        decay2.velocity = 200.90
+
+        XCTAssertTrue(decay2.velocity.approximatelyEqual(to: 201.53, epsilon: 0.01))
+        XCTAssertTrue(decay2.toValue.approximatelyEqual(to: 100.6666, epsilon: 0.0001))
+    }
+
     // MARK: - CAKeyframeAnimationEmittable Tests
 
     func testCreateCAKeyframeAnimationFromDecayAnimation() {
         let decay = DecayAnimation<CGFloat>()
         decay.velocity = 2000.0
 
-        let keyframeAnimation = decay.keyframeAnimation()
+        let keyframeAnimation = decay.keyframeAnimation(forFramerate: 60)
 
         XCTAssertEqual(keyframeAnimation.calculationMode, .discrete)
         XCTAssertFalse(keyframeAnimation.values?.isEmpty ?? true)
         XCTAssertFalse(keyframeAnimation.keyTimes?.isEmpty ?? true)
-        XCTAssertTrue(keyframeAnimation.duration.approximatelyEqual(to: 4.133))
+        XCTAssertTrue(keyframeAnimation.duration.approximatelyEqual(to: 4.166))
     }
 
     override class func tearDown() {

--- a/Tests/MotionTests/SpringAnimationTests.swift
+++ b/Tests/MotionTests/SpringAnimationTests.swift
@@ -257,12 +257,12 @@ final class SpringAnimationTests: XCTestCase {
         spring.toValue = CGRect(x: 0, y: 0, width: 320, height: 320)
         spring.configure(response: 1.0, dampingRatio: 1.0)
 
-        let keyframeAnimation = spring.keyframeAnimation()
+        let keyframeAnimation = spring.keyframeAnimation(forFramerate: 60)
 
         XCTAssertEqual(keyframeAnimation.calculationMode, .discrete)
         XCTAssertFalse(keyframeAnimation.values?.isEmpty ?? true)
         XCTAssertFalse(keyframeAnimation.keyTimes?.isEmpty ?? true)
-        XCTAssertTrue(keyframeAnimation.duration.approximatelyEqual(to: 2.383))
+        XCTAssertTrue(keyframeAnimation.duration.approximatelyEqual(to: 2.3999))
     }
 
     override class func tearDown() {


### PR DESCRIPTION
This adds the ability to get the destination for a `DecayAnimation`. It also allows the ability to set the destination for a `DecayAnimation` (similar to how one can with `UIScrollView`). Setting the `toValue` on a `DecayAnimation` will result in the `velocity` being adjusted so that the `DecayAnimation` will stop at the supplied `toValue`.

This also adds the ability to adjust how the decay will end with regards to rounded values. Setting a value of 1.0 will result in the `DecayAnimation` always stopping on whole point values (whereas setting something like `1 / screenScale` will allow it to stop on pixel values).

Implements https://github.com/b3ll/Motion/issues/28 (cc @cdoncarroll)