### PR TITLE
Pause animation driver if necessary when unobserving animations

### DIFF
--- a/Sources/Motion/Utilities/Animator.swift
+++ b/Sources/Motion/Utilities/Animator.swift
@@ -92,6 +92,7 @@ public class Animator: NSObject, AnimationDriverObserver {
 
     internal func unobserve(_ animation: Animation) {
         runningAnimations.remove(animation)
+        animationDriver?.isPaused = runningAnimations.count == 0
         animation.enabledDidChange = { _ in }
     }
 


### PR DESCRIPTION
If the last running animation is deallocated while it is still enabled then the animation driver will remain unpaused. This PR adds an additional call to pause the animation driver if necessary when unobserving animations.

Tested by deallocating an in-flight animation, and observing that calls to `Animator.tick(frame:)` stop occuring.