### PR TITLE
Introduce AnimationEnvironment to address #18

### DIFF
--- a/Sources/Motion/Animations/AnimationGroup.swift
+++ b/Sources/Motion/Animations/AnimationGroup.swift
@@ -25,9 +25,9 @@ public final class AnimationGroup: Animation {
      - Parameters:
         - animations: The animations to run as a group.
      */
-    init(_ animations: Animation...) {
+    init(environment: AnimationEnvironment = .default, _ animations: Animation...) {
         self.animations = animations
-        super.init()
+        super.init(environment: environment)
     }
 
     /// Returns whether or not all of the animations have resolved.

--- a/Sources/Motion/Animations/BasicAnimation.swift
+++ b/Sources/Motion/Animations/BasicAnimation.swift
@@ -69,10 +69,11 @@ public final class BasicAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
 
      - Parameters:
         - easingFunction: The easing function the animation should use.
+        - environment: The ``AnimationEnvironment`` where this animation will run.
      */
-    public init(easingFunction: EasingFunction<Value.SIMDType> = .linear) {
+    public init(easingFunction: EasingFunction<Value.SIMDType> = .linear, environment: AnimationEnvironment = .default) {
         self.easingFunction = easingFunction
-        super.init()
+        super.init(environment: environment)
     }
 
     override public func start() {

--- a/Sources/Motion/Animations/DecayAnimation.swift
+++ b/Sources/Motion/Animations/DecayAnimation.swift
@@ -115,11 +115,12 @@ public final class DecayAnimation<Value: SIMDRepresentable>: ValueAnimation<Valu
 
      - Parameters:
         - initialValue: The initial value to be set for `value`.
-        - decayConstnat: The decay constant. Defaults to `UIScrollViewDecayConstant`.
+        - decayConstant: The decay constant. Defaults to `UIScrollViewDecayConstant`.
+        - environment: The ``AnimationEnvironment`` where this animation will run.
      */
-    public init(initialValue: Value = .zero, decayConstant: Value.SIMDType.Scalar = Value.SIMDType.Scalar(UIScrollViewDecayConstant)) {
+    public init(initialValue: Value = .zero, decayConstant: Value.SIMDType.Scalar = Value.SIMDType.Scalar(UIScrollViewDecayConstant), environment: AnimationEnvironment = .default) {
         self.decay = DecayFunction(decayConstant: decayConstant)
-        super.init()
+        super.init(environment: environment)
         self.value = initialValue
     }
 

--- a/Sources/Motion/Animations/SpringAnimation.swift
+++ b/Sources/Motion/Animations/SpringAnimation.swift
@@ -155,9 +155,10 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
      - Parameters:
         - stiffness: How stiff the spring should be.
         - damping: How much friction should be exerted on the spring.
+        - environment: The ``AnimationEnvironment`` where this animation will run.
      */
-    public convenience init(initialValue: Value = .zero, stiffness: Value.SIMDType.Scalar, damping: Value.SIMDType.Scalar) {
-        self.init(initialValue: initialValue)
+    public convenience init(initialValue: Value = .zero, stiffness: Value.SIMDType.Scalar, damping: Value.SIMDType.Scalar, environment: AnimationEnvironment = .default) {
+        self.init(initialValue: initialValue, environment: environment)
         configure(stiffness: stiffness, damping: damping)
     }
 
@@ -171,11 +172,12 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
           - `0.0`: An infinitely oscillating spring.
           - `1.0`: A critically damped spring.
           - `0.0 < value > 1.0`: An underdamped spring.
+        - environment: The ``AnimationEnvironment`` where this animation will run.
 
      - Note: For more information on how these values work, check out the WWDC talk on fluid animations: https://developer.apple.com/videos/play/wwdc2018/803/.
      */
-    public convenience init(initialValue: Value = .zero, response: Value.SIMDType.Scalar, dampingRatio: Value.SIMDType.Scalar) {
-        self.init(initialValue: initialValue)
+    public convenience init(initialValue: Value = .zero, response: Value.SIMDType.Scalar, dampingRatio: Value.SIMDType.Scalar, environment: AnimationEnvironment = .default) {
+        self.init(initialValue: initialValue, environment: environment)
         configure(response: response, dampingRatio: dampingRatio)
     }
 

--- a/Sources/Motion/Animations/SpringAnimation.swift
+++ b/Sources/Motion/Animations/SpringAnimation.swift
@@ -141,10 +141,11 @@ public final class SpringAnimation<Value: SIMDRepresentable>: ValueAnimation<Val
 
      - Parameters:
         - initialValue: The value to start animating from.
+        - environment: The ``AnimationEnvironment`` where this animation will run.
      */
-    public init(initialValue: Value = .zero) {
+    public init(initialValue: Value = .zero, environment: AnimationEnvironment = .default) {
         self.spring = SpringFunction()
-        super.init()
+        super.init(environment: environment)
         self.value = initialValue
     }
 

--- a/Sources/Motion/Animations/ValueAnimation.swift
+++ b/Sources/Motion/Animations/ValueAnimation.swift
@@ -39,7 +39,7 @@ open class Animation: AnimationDriverObserver {
      */
     open var completion: (() -> Void)? = nil
 
-    internal let environment: AnimationEnvironment
+    internal weak var environment: AnimationEnvironment?
 
     /// Default initializer. Animations must be strongly held to continue to animate.
     public init(environment: AnimationEnvironment) {
@@ -51,14 +51,14 @@ open class Animation: AnimationDriverObserver {
     private func registerWithAnimatorIfNeeded() {
         guard !registeredWithAnimator else { return }
 
-        environment.animator.observe(self)
+        environment?.animator.observe(self)
 
         registeredWithAnimator = true
     }
 
     deinit {
         if registeredWithAnimator {
-            environment.animator.unobserve(self)
+            environment?.animator.unobserve(self)
         }
     }
 

--- a/Sources/Motion/Protocols/AnimationEnvironment.swift
+++ b/Sources/Motion/Protocols/AnimationEnvironment.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+#if os(macOS)
+import AppKit
+import CoreGraphics
+#else
+public typealias CGDirectDisplayID = UInt32
+#endif
+
+/**
+ Adopted by types that can provide an ``Animator``  to drive Motion animations in a given environment.
+
+ - Note: The animation environment is only relevant for native Mac apps.
+ On iOS, you don't have to specify an animation environment and using ``AnimationEnvironment/default`` will always work.
+ */
+public protocol AnimationEnvironment: AnyObject {
+    /// The ``Animator`` type to be used for animations in this environment.
+    var animator: Animator { get }
+
+    #if os(macOS)
+    /// Identifier for the CoreGraphics display represented by this environment.
+    var displayID: CGDirectDisplayID? { get }
+
+    /// The preferred FPS for animations running in this environment.
+    var preferredFramesPerSecond: Int { get }
+    #endif
+}
+
+public extension AnimationEnvironment where Self == DefaultAnimationEnvironment {
+    /**
+     The default animation environment for the current device.
+
+     On iOS, this will be the shared animator.
+
+     On macOS, this will be the environment representing the main screen (`NSScreen.main`).
+
+     - Warning: On macOS, you should always provide the most specific animation environment available
+     when initializing an animation, such as the `NSView` where the animation will be rendered.
+     Failing to do so may result in animations that don't use the optimal frame rate for the Mac's screen,
+     or assertion failures in debug builds when an environment can't be inferred automatically.
+     - SeeAlso: To learn more about environment specificity on macOS, see the documentation for ``AnimationEnvironmentProxy``.
+    */
+    static var `default`: AnimationEnvironment { DefaultAnimationEnvironment.shared }
+}
+
+// MARK: - iOS Stubs
+
+#if canImport(UIKit)
+public extension AnimationEnvironment {
+    var animator: Animator { Animator.shared }
+}
+
+public final class DefaultAnimationEnvironment: AnimationEnvironment {
+    public static let shared = DefaultAnimationEnvironment()
+}
+#endif

--- a/Sources/Motion/Utilities/AnimationEnvironmentProxy.swift
+++ b/Sources/Motion/Utilities/AnimationEnvironmentProxy.swift
@@ -1,0 +1,99 @@
+#if os(macOS)
+
+import AppKit
+
+/**
+ Protocol adopted by types that implement ``AnimationEnvironment`` by leveraging another type's implementation.
+
+ Motion extends common AppKit interface elements so that they can be used as animation environments:
+
+ - `NSView`/`NSViewController`
+ - `NSWindow`/`NSWindowController`
+ - `NSApplication`
+
+ The AppKit types above are listed from most to least specific.
+ Prefer to use the most specific environment whenever possible to ensure the best results for your animations.
+
+ For example, if you're configuring an animation inside of a view controller, you may use the view controller itself
+ as the environment parameter for your animation:
+
+ ```swift
+ override func viewDidLoad() {
+     super.viewDidLoad()
+
+     let anim = BasicAnimation<CGFloat>(environment: self)
+     // ...
+ }
+ ```
+
+ - Note: These extensions will crash in debug builds when attempting to start an animation before the environment can be resolved,
+ such as when an animation using an `NSView` as its environment starts before the view is in a window. In the view controller example above,
+ it wouldn't be safe to start the animation in `viewDidLoad`. Generally, a safe place to start an animation tied to a view or view controller
+ is any time after `viewDidAppear` and before `viewDidDisappear`, which is when the view is in a window, and its window is on screen.
+ */
+public protocol AnimationEnvironmentProxy: AnimationEnvironment {
+    var proxiedAnimationEnvironment: AnimationEnvironment { get }
+}
+
+public extension AnimationEnvironmentProxy {
+    var displayID: CGDirectDisplayID? { proxiedAnimationEnvironment.displayID }
+    var preferredFramesPerSecond: Int { proxiedAnimationEnvironment.preferredFramesPerSecond }
+    var animator: Animator { proxiedAnimationEnvironment.animator }
+}
+
+extension NSWindow: AnimationEnvironmentProxy {
+    public var proxiedAnimationEnvironment: AnimationEnvironment {
+        guard let screen else {
+            assertionFailure("Motion can't run an animation on window \(self) before it's on screen")
+            return DefaultAnimationEnvironment.shared
+        }
+        return screen
+    }
+}
+
+extension NSView: AnimationEnvironmentProxy {
+    public var proxiedAnimationEnvironment: AnimationEnvironment {
+        guard let window else {
+            assertionFailure("Motion can't run an animation on view \(self) before it's in a window")
+            return DefaultAnimationEnvironment.shared
+        }
+        return window
+    }
+}
+
+extension NSViewController: AnimationEnvironmentProxy {
+    public var proxiedAnimationEnvironment: AnimationEnvironment {
+        guard isViewLoaded else {
+            assertionFailure("Motion can't run an animation on view controller \(self) before its view has been loaded")
+            return DefaultAnimationEnvironment.shared
+        }
+        return view
+    }
+}
+
+extension NSWindowController: AnimationEnvironmentProxy {
+    public var proxiedAnimationEnvironment: AnimationEnvironment {
+        guard isWindowLoaded, let window else {
+            assertionFailure("Motion can't run an animation on window controller \(self) before its window is available")
+            return DefaultAnimationEnvironment.shared
+        }
+        return window
+    }
+}
+
+extension NSApplication: AnimationEnvironmentProxy {
+    public var proxiedAnimationEnvironment: AnimationEnvironment {
+        if let keyWindow {
+            return keyWindow
+        } else if let mainWindow {
+            return mainWindow
+        } else if let visibleWindow = windows.first(where: { $0.isVisible }) {
+            return visibleWindow
+        } else {
+            assertionFailure("Motion can't run an animation on application \(self) without any visible window")
+            return DefaultAnimationEnvironment.shared
+        }
+    }
+}
+
+#endif

--- a/Sources/Motion/Utilities/Animator.swift
+++ b/Sources/Motion/Utilities/Animator.swift
@@ -19,7 +19,7 @@ public class Animator: NSObject, AnimationDriverObserver {
             if let _animationDriverStore = _animationDriverStore {
                 return _animationDriverStore
             }
-            _animationDriverStore = SystemAnimationDriver(environment: environment)
+            _animationDriverStore = SystemAnimationDriver(environment: environment ?? .default)
             _animationDriverStore?.observer = self
             return _animationDriverStore
         }
@@ -29,9 +29,9 @@ public class Animator: NSObject, AnimationDriverObserver {
     internal var runningAnimations: NSHashTable<Animation> = .weakObjects()
 
     #if os(macOS)
-    private let environment: AnimationEnvironment
+    private weak var environment: AnimationEnvironment?
     #else
-    private let environment: AnimationEnvironment
+    private weak var environment: AnimationEnvironment?
     #endif
 
     internal init(environment: AnimationEnvironment) {
@@ -74,7 +74,7 @@ public class Animator: NSObject, AnimationDriverObserver {
         }
     }
     #else
-    var preferredFramesPerSecond: Int { environment.preferredFramesPerSecond }
+    var preferredFramesPerSecond: Int { environment?.preferredFramesPerSecond ?? DefaultAnimationEnvironment.shared.preferredFramesPerSecond }
     #endif
 
     #if canImport(UIKit)

--- a/Sources/Motion/Utilities/Animator.swift
+++ b/Sources/Motion/Utilities/Animator.swift
@@ -19,7 +19,7 @@ public class Animator: NSObject, AnimationDriverObserver {
             if let _animationDriverStore = _animationDriverStore {
                 return _animationDriverStore
             }
-            _animationDriverStore = SystemAnimationDriver()
+            _animationDriverStore = SystemAnimationDriver(environment: environment)
             _animationDriverStore?.observer = self
             return _animationDriverStore
         }
@@ -28,7 +28,17 @@ public class Animator: NSObject, AnimationDriverObserver {
     private var _animationDriverStore: AnimationDriver?
     internal var runningAnimations: NSHashTable<Animation> = .weakObjects()
 
-    #if os(iOS)
+    #if os(macOS)
+    private let environment: AnimationEnvironment
+    #else
+    private let environment: AnimationEnvironment
+    #endif
+
+    internal init(environment: AnimationEnvironment) {
+        self.environment = environment
+    }
+
+    #if canImport(UIKit)
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
     /**
      The preferred frame rate range for animations being run.
@@ -64,15 +74,13 @@ public class Animator: NSObject, AnimationDriverObserver {
         }
     }
     #else
-    var preferredFramesPerSecond: Int {
-        let defaultFPS = 60
-
-        return defaultFPS
-    }
+    var preferredFramesPerSecond: Int { environment.preferredFramesPerSecond }
     #endif
 
+    #if canImport(UIKit)
     // The shared animator that runs all of Motion's animations.
-    public static let shared = Animator()
+    public static let shared = Animator(environment: .default)
+    #endif
 
     // MARK: - Animations
 

--- a/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
+++ b/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
@@ -61,7 +61,7 @@ extension CAKeyframeAnimationEmittable {
         if let framerate = framerate {
             dt = 1.0 / TimeInterval(framerate)
         } else {
-            dt = 1.0 / TimeInterval(Animator.shared.preferredFramesPerSecond)
+            dt = 1.0 / TimeInterval(environment.animator.preferredFramesPerSecond)
         }
 
         var values = [AnyObject]()

--- a/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
+++ b/Sources/Motion/Utilities/CAKeyframeAnimationEmittable.swift
@@ -61,7 +61,7 @@ extension CAKeyframeAnimationEmittable {
         if let framerate = framerate {
             dt = 1.0 / TimeInterval(framerate)
         } else {
-            dt = 1.0 / TimeInterval(environment.animator.preferredFramesPerSecond)
+            dt = 1.0 / TimeInterval(environment?.animator.preferredFramesPerSecond ?? 60)
         }
 
         var values = [AnyObject]()

--- a/Sources/Motion/Utilities/NSScreen+AnimationEnvironment.swift
+++ b/Sources/Motion/Utilities/NSScreen+AnimationEnvironment.swift
@@ -1,0 +1,57 @@
+#if os(macOS)
+import AppKit
+
+public final class DefaultAnimationEnvironment: NSScreen {
+    public static var shared: AnimationEnvironment {
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            fatalError("Motion can't run because this Mac doesn't have a screen")
+        }
+        return screen
+    }
+}
+
+extension NSScreen: AnimationEnvironment {
+    private var environmentStorage: AnimationEnvironmentStorage { AnimationEnvironmentStorage.shared }
+
+    public var animator: Animator { environmentStorage.animator(for: self) }
+
+    public var displayID: CGDirectDisplayID? {
+        guard let number = deviceDescription[.screenNumber] as? NSNumber else {
+            assertionFailure("NSScreenNumber for \(self) is not an NSNumber")
+            return nil
+        }
+        return number.uint32Value
+    }
+
+    public var preferredFramesPerSecond: Int {
+        guard #available(macOS 12.0, *) else { return 60 }
+        let fps = maximumFramesPerSecond
+        guard fps > 0 else { return 60 }
+        return fps
+    }
+}
+
+private extension NSDeviceDescriptionKey {
+    static let screenNumber = NSDeviceDescriptionKey("NSScreenNumber")
+}
+
+private final class AnimationEnvironmentStorage {
+    static let shared = AnimationEnvironmentStorage()
+
+    private var animatorsByDisplayID = [CGDirectDisplayID: Animator]()
+
+    func animator(for screen: NSScreen) -> Animator {
+        guard let displayID = screen.displayID else {
+            fatalError("Motion failed to get the CGDirectDisplayID for screen \(screen)")
+        }
+
+        if let existingAnimator = animatorsByDisplayID[displayID] {
+            return existingAnimator
+        } else {
+            let newAnimator = Animator(environment: screen)
+            animatorsByDisplayID[displayID] = newAnimator
+            return newAnimator
+        }
+    }
+}
+#endif

--- a/Tests/MotionTests/BasicAnimationTests.swift
+++ b/Tests/MotionTests/BasicAnimationTests.swift
@@ -130,3 +130,14 @@ final class BasicAnimationTests: XCTestCase {
     }
 
 }
+
+#if os(macOS)
+extension Animator {
+    static let shared: Animator = {
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            fatalError("Motion's tests can't run because this Mac doesn't have any screens!")
+        }
+        return screen.animator
+    }()
+}
+#endif


### PR DESCRIPTION
This introduces the `AnimationEnvironment` protocol, which is used by subclasses of `Animation` on macOS in order to determine the display where the animation will occur, so that the problem described in #18 can be addressed.

There's no change for existing clients on iOS, where `AnimationEnvironment.default` is equivalent to `Animator.shared`, which I have compiled out of the macOS version since it's semantically incorrect.

Clients may still initialize animations without specifying an environment even on macOS. When using `AnimationEnvironment.default` on macOS, Motion tries its best to provide an environment, preferring to use `NSScreen.main` when that's available.

However, it's still possible for there to be no screen at all on a Mac, and in that case Motion will still fatal error, although I think a future pull request could introduce a fallback for this edge case that just causes all animations to resolve instantly if there's no display.

In practice, clients using Motion on macOS will now be able to initialize any one of the animation types with a specific environment. I've implemented extensions for common AppKit types that work as environments, listed below from most specific to least specific:

- `NSView`/`NSViewController`
- `NSWindow`/`NSWindowController`
- `NSApplication`

The best value to use for the environment will always be the most specific, so `NSView` or `NSViewController`. Since most animations happen in one of those, just using `self` as the environment will work in most cases.

With that, initializing an animation in a subclass of `NSViewController` looks something like this:

```swift
private var animation: BasicAnimation<CGFloat>?

override func viewDidLoad() {
    super.viewDidLoad()

    animation = BasicAnimation(environment: self)
}
```

Taking the example above, let's say the animation starts out as the result of a button click or some gesture. By the time the animation starts, the driver used for the animation will be the one corresponding to the screen where the window containing the view controller's view is currently on. If the window is moved into another screen and the animation is started again, it will then use the driver for the new screen.

I'm not handling the case where a window is moved between screens in the middle of an animation, but I haven't noticed any significant issues with that during my tests.

The main caveat with this approach is that the moment when an animation gets started becomes critical on macOS. In the example above, if I called `start()` on the animation within `viewDidLoad`, this would result in an assertion failure from Motion, because in `viewDidLoad` the view has no information about its window, let alone which screen it's going to be on.

I've decided to use assertion failures to highlight these situations on macOS because they should only surface as a result of API misuse or really weird edge cases, so hopefully clients will catch these mistakes before their app is put into production use.

These are assertion failures though, so for release builds Motion falls back to using the main screen if an animation starts before it can resolve its environment.

Overall, I think this does a decent job of addressing #18 without making Motion too complicated for existing iOS clients, or even macOS clients who don't care about these details.